### PR TITLE
Add feature for 5 day weather forecast

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "openweathermap.org/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/lib/services/fetch-weather.ts
+++ b/src/app/lib/services/fetch-weather.ts
@@ -8,15 +8,22 @@ export async function fetchWeather(city: string): Promise<ApiResponse> {
   }
 
   const response = await fetch(
-    `https://api.openweathermap.org/data/2.5/weather?q=${city}&units=metric&appid=${apiKey}`
+    `https://api.openweathermap.org/data/2.5/forecast?q=${city}&units=metric&appid=${apiKey}`
   );
 
   if (!response.ok) {
     throw new Error("Failed to fetch weather data");
   }
 
-  const data = await response.json();
+  const data: ApiResponse = await response.json();
   console.log(`Weather data for ${city}:`, data);
+  const filteredData = data.list.filter((item) =>
+    item.dt_txt.includes("12:00:00")
+  );
+  console.log("filtered data", filteredData);
 
-  return data;
+  return {
+    city: data.city,
+    list: filteredData,
+  };
 }

--- a/src/app/lib/types/api-response.ts
+++ b/src/app/lib/types/api-response.ts
@@ -1,17 +1,22 @@
 export type ApiResponse = {
-  name: string;
-  dt: number;
-  main: {
-    temp: number;
-    feels_like: number;
-    temp_min: number;
-    temp_max: number;
-    humidity: number;
+  city: {
+    name: string;
   };
-  wind: {
-    speed: number;
-  };
-  weather: {
-    description: string;
+  list: {
+    dt: number;
+    dt_txt: string;
+    main: {
+      temp: number;
+      feels_like: number;
+      temp_min: number;
+      temp_max: number;
+      humidity: number;
+    };
+    wind: {
+      speed: number;
+    };
+    weather: {
+      description: string;
+    }[];
   }[];
 };

--- a/src/app/lib/types/api-response.ts
+++ b/src/app/lib/types/api-response.ts
@@ -17,6 +17,7 @@ export type ApiResponse = {
     };
     weather: {
       description: string;
+      icon: string;
     }[];
   }[];
 };

--- a/src/app/lib/types/forecast-list-item.ts
+++ b/src/app/lib/types/forecast-list-item.ts
@@ -5,5 +5,6 @@ export type ForecastListItem = {
   };
   weather: {
     description: string;
+    icon: string;
   }[];
 };

--- a/src/app/lib/types/forecast-list-item.ts
+++ b/src/app/lib/types/forecast-list-item.ts
@@ -1,0 +1,9 @@
+export type ForecastListItem = {
+  dt: number;
+  main: {
+    temp: number;
+  };
+  weather: {
+    description: string;
+  }[];
+};

--- a/src/app/ui/weather-card-list/weather-card-list.tsx
+++ b/src/app/ui/weather-card-list/weather-card-list.tsx
@@ -1,0 +1,23 @@
+import { ForecastListItem } from "@/app/lib/types/forecast-list-item";
+import WeatherCardSmall from "../weather-card-small/weather-card-small";
+
+interface WeatherCardListProps {
+  items: ForecastListItem[];
+}
+
+export default function WeatherCardList({ items }: WeatherCardListProps) {
+  const slicedItems = items.slice(1, 5);
+  console.log("sliced items in list", slicedItems);
+  return (
+    <ul className="grid grid-cols-1 sm:grid-cols-4 gap-6">
+      {slicedItems.map((item, index) => (
+        <li
+          key={index}
+          className="rounded-lg border border-white p-4 border-opacity-80"
+        >
+          <WeatherCardSmall item={item} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/app/ui/weather-card-list/weather-card-list.tsx
+++ b/src/app/ui/weather-card-list/weather-card-list.tsx
@@ -9,7 +9,7 @@ export default function WeatherCardList({ items }: WeatherCardListProps) {
   const slicedItems = items.slice(1, 5);
   console.log("sliced items in list", slicedItems);
   return (
-    <ul className="grid grid-cols-1 sm:grid-cols-4 gap-6">
+    <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6">
       {slicedItems.map((item, index) => (
         <li
           key={index}

--- a/src/app/ui/weather-card-small/weather-card-small.tsx
+++ b/src/app/ui/weather-card-small/weather-card-small.tsx
@@ -1,0 +1,17 @@
+import { capitalizeFirstLetter } from "@/app/lib/hooks/capitalizeFirstLetter";
+import { getDayOfWeek } from "@/app/lib/hooks/getDayOfWeek";
+import { ForecastListItem } from "@/app/lib/types/forecast-list-item";
+
+interface WeatherCardSmallProps {
+  item: ForecastListItem;
+}
+
+export default function WeatherCardSmall({ item }: WeatherCardSmallProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <p>{getDayOfWeek(item.dt)}</p>
+      <p>{capitalizeFirstLetter(item.weather[0].description)}</p>
+      <p>{item.main.temp}°C</p>
+    </div>
+  );
+}

--- a/src/app/ui/weather-card-small/weather-card-small.tsx
+++ b/src/app/ui/weather-card-small/weather-card-small.tsx
@@ -9,7 +9,7 @@ interface WeatherCardSmallProps {
 export default function WeatherCardSmall({ item }: WeatherCardSmallProps) {
   return (
     <div className="flex flex-col gap-4">
-      <p>{getDayOfWeek(item.dt)}</p>
+      <p className="font-medium">{getDayOfWeek(item.dt)}</p>
       <p>{capitalizeFirstLetter(item.weather[0].description)}</p>
       <p>{item.main.temp}°C</p>
     </div>

--- a/src/app/ui/weather-card-small/weather-card-small.tsx
+++ b/src/app/ui/weather-card-small/weather-card-small.tsx
@@ -1,6 +1,7 @@
 import { capitalizeFirstLetter } from "@/app/lib/hooks/capitalizeFirstLetter";
 import { getDayOfWeek } from "@/app/lib/hooks/getDayOfWeek";
 import { ForecastListItem } from "@/app/lib/types/forecast-list-item";
+import Image from "next/image";
 
 interface WeatherCardSmallProps {
   item: ForecastListItem;
@@ -10,7 +11,18 @@ export default function WeatherCardSmall({ item }: WeatherCardSmallProps) {
   return (
     <div className="flex flex-col gap-4">
       <p className="font-medium">{getDayOfWeek(item.dt)}</p>
-      <p>{capitalizeFirstLetter(item.weather[0].description)}</p>
+      <div className="flex items-center gap-1">
+        <div>
+          <Image
+            src={`https://openweathermap.org/img/wn/${item.weather[0].icon}@2x.png`}
+            alt={item.weather[0].description}
+            width={24}
+            height={24}
+          />
+        </div>
+        <p>{capitalizeFirstLetter(item.weather[0].description)}</p>
+      </div>
+
       <p>{item.main.temp}°C</p>
     </div>
   );

--- a/src/app/ui/weather-card/weather-card.tsx
+++ b/src/app/ui/weather-card/weather-card.tsx
@@ -16,17 +16,19 @@ export default function WeatherCard({ weatherData }: WeatherCardProps) {
     <div className="flex flex-col gap-8">
       <div className="flex flex-col justify-between p-4 gap-4 w-full bg-black text-white rounded-lg border border-white font-semibold border-opacity-80">
         <div>
-          <p>{getDayOfWeek(weatherData.dt)}</p>
-          <p className="self-start">{weatherData.name}</p>
+          <p>{getDayOfWeek(weatherData.list[0].dt)}</p>
+          <p className="self-start">{weatherData.city.name}</p>
         </div>
-        <p className="xs:self-center text-4xl">{weatherData.main.temp}°C</p>
+        <p className="xs:self-center text-4xl">
+          {weatherData.list[0].main.temp}°C
+        </p>
         <div className="flex flex-col gap-1 xs:justify-between xs:flex-row">
           <p className="self-start">
-            {capitalizeFirstLetter(weatherData.weather[0].description)}
+            {capitalizeFirstLetter(weatherData.list[0].weather[0].description)}
           </p>
           <div className="flex xs:self-end gap-2">
-            <p>H: {weatherData.main.temp_max}°C</p>
-            <p>L: {weatherData.main.temp_min}°C</p>
+            <p>H: {weatherData.list[0].main.temp_max}°C</p>
+            <p>L: {weatherData.list[0].main.temp_min}°C</p>
           </div>
         </div>
       </div>
@@ -41,14 +43,16 @@ export default function WeatherCard({ weatherData }: WeatherCardProps) {
             />
             <p>Feels like</p>
           </div>
-          <p className="font-semibold">{weatherData.main.feels_like}°C</p>
+          <p className="font-semibold">
+            {weatherData.list[0].main.feels_like}°C
+          </p>
         </div>
         <div className="rounded-lg border border-white p-4 flex flex-col gap-4 border-opacity-80">
           <div className="flex gap-1">
             <Image src={"/icons/wind.svg"} alt="Wind" width={16} height={16} />
             <p>Wind</p>
           </div>
-          <p className="font-semibold">{weatherData.wind.speed} m/s</p>
+          <p className="font-semibold">{weatherData.list[0].wind.speed} m/s</p>
         </div>
         <div className="rounded-lg border border-white p-4 flex flex-col gap-4 border-opacity-80">
           <div className="flex gap-1">
@@ -61,7 +65,7 @@ export default function WeatherCard({ weatherData }: WeatherCardProps) {
             <p>Humidity</p>
           </div>
 
-          <p className="font-semibold">{weatherData.main.humidity}%</p>
+          <p className="font-semibold">{weatherData.list[0].main.humidity}%</p>
         </div>
       </div>
     </div>

--- a/src/app/ui/weather-card/weather-card.tsx
+++ b/src/app/ui/weather-card/weather-card.tsx
@@ -23,9 +23,22 @@ export default function WeatherCard({ weatherData }: WeatherCardProps) {
           {weatherData.list[0].main.temp}°C
         </p>
         <div className="flex flex-col gap-1 xs:justify-between xs:flex-row">
-          <p className="self-start">
-            {capitalizeFirstLetter(weatherData.list[0].weather[0].description)}
-          </p>
+          <div className="self-start flex gap-1 items-center">
+            <div>
+              <Image
+                src={`https://openweathermap.org/img/wn/${weatherData.list[0].weather[0].icon}@2x.png`}
+                alt={weatherData.list[0].weather[0].description}
+                height={24}
+                width={24}
+              />
+            </div>
+            <p>
+              {capitalizeFirstLetter(
+                weatherData.list[0].weather[0].description
+              )}
+            </p>
+          </div>
+
           <div className="flex xs:self-end gap-2">
             <p>H: {weatherData.list[0].main.temp_max}°C</p>
             <p>L: {weatherData.list[0].main.temp_min}°C</p>

--- a/src/app/ui/weather-widget.tsx
+++ b/src/app/ui/weather-widget.tsx
@@ -5,6 +5,7 @@ import { fetchWeather } from "../lib/services/fetch-weather";
 import { ApiResponse } from "../lib/types/api-response";
 import WeatherCard from "./weather-card/weather-card";
 import WeatherForm from "./weather-form/weather-form";
+import WeatherCardList from "./weather-card-list/weather-card-list";
 
 export default function WeatherWidget() {
   const [city, setCity] = useState<string>("");
@@ -42,6 +43,9 @@ export default function WeatherWidget() {
       </div>
       <div className="w-4/5 mx-auto">
         <WeatherCard weatherData={weatherData} />
+      </div>
+      <div className="w-4/5 mx-auto">
+        {weatherData && <WeatherCardList items={weatherData.list} />}
       </div>
     </section>
   );

--- a/src/app/ui/weather-widget.tsx
+++ b/src/app/ui/weather-widget.tsx
@@ -41,11 +41,17 @@ export default function WeatherWidget() {
           loading={isloading}
         />
       </div>
-      <div className="w-4/5 mx-auto">
+      <div className="w-4/5 mx-auto flex flex-col gap-4">
+        <div>
+          <h1 className="font-medium">Today&apos;s weather</h1>
+        </div>
         <WeatherCard weatherData={weatherData} />
       </div>
-      <div className="w-4/5 mx-auto">
-        {weatherData && <WeatherCardList items={weatherData.list} />}
+      <div className="w-4/5 mx-auto flex flex-col gap-4">
+        <div>
+          <h2 className="font-medium">Weather next 4 days</h2>
+        </div>
+        <div>{weatherData && <WeatherCardList items={weatherData.list} />}</div>
       </div>
     </section>
   );


### PR DESCRIPTION
**This PR includes the following changes:**

- Updates fn `fetchWeather` to fetch data for a 5 day weather forecast instead of only the current day
- Adds new type for the cards that display the weather for the next 4 days
- Adds component to display data for the next 4 day's weather
- Includes icons in the cards 
- Updates `next.config.ts` to allow images from `openweathermap.org`
- Updates styles for the weather widget